### PR TITLE
Update AbstractOEmbedProvider.java

### DIFF
--- a/src/main/java/com/nmote/oembed/AbstractOEmbedProvider.java
+++ b/src/main/java/com/nmote/oembed/AbstractOEmbedProvider.java
@@ -57,16 +57,17 @@ public abstract class AbstractOEmbedProvider implements OEmbedProvider {
      */
     public <T extends OEmbed> T get(String url, final Class<T> embedClass) throws IOException {
         Request request = new Request.Builder().url(url).build();
-        Response response = httpClient.newCall(request).execute();
-        if (response.isSuccessful()) {
-            try (InputStream in = response.body().byteStream()) {
-                T result = mapper.readValue(in, embedClass);
-                checkEmbedForErrors(result);
-                return result;
+        try (Response response = httpClient.newCall(request).execute()) { // auto-close response
+            if (response.isSuccessful()) {
+                try (InputStream in = response.body().byteStream()) {
+                    T result = mapper.readValue(in, embedClass);
+                    checkEmbedForErrors(result);
+                    return result;
+                }
+            } else {
+                throw new IOException(
+                        String.format("HTTP %d/%s while getting %s", response.code(), response.message(), url));
             }
-        } else {
-            throw new IOException(
-                    String.format("HTTP %d/%s while getting %s", response.code(), response.message(), url));
         }
     }
 


### PR DESCRIPTION
in the log I can see these lines:

Apr 01, 2021 6:43:03 PM okhttp3.internal.platform.Platform log
WARNING: A connection to https://m.facebook.com/ was leaked. Did you forget to close a response body? To see where this was allocated, set the OkHttpClient logger level to FINE: Logger.getLogger(OkHttpClient.class.getName()).setLevel(Level.FINE);
Apr 01, 2021 6:43:29 PM okhttp3.internal.platform.Platform log
WARNING: A connection to http://vimeo.com/ was leaked. Did you forget to close a response body? To see where this was allocated, set the OkHttpClient logger level to FINE: Logger.getLogger(OkHttpClient.class.getName()).setLevel(Level.FINE);